### PR TITLE
Update readme to include node install on decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ $ cd ../ingestor
 $ npm install
 $ cd ..
 ```
+Repeat this for the decorator function as well.
 
 ## Deploy Lambda Functions
 


### PR DESCRIPTION
Your directions and package fail to reference the necessity of building decorator as well. I suggest adding this.