### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -59,7 +59,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 120
       CodeUri: decorator/
       Policies:


### PR DESCRIPTION
CloudFormation templates in aws-vpc-flow-log-appender have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.